### PR TITLE
feat: add cache provider

### DIFF
--- a/src/js/agent/add-agent/index.ts
+++ b/src/js/agent/add-agent/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AbortCall, CacheItem, Header, QueryParam } from '../../index';
+import { AbortCall, Header, QueryParam } from '../../index';
 import { AgentFetchParams, agents } from '../agents';
+import { AgentCache, InMemoryCache } from '../../cache-provider';
 
 export interface AgentOptions {
     name: string;
@@ -8,20 +9,17 @@ export interface AgentOptions {
     headers?: Header[];
     query?: QueryParam[];
     runner<T>(options: AgentFetchParams<T>): AbortCall;
+    cache?: AgentCache;
 }
 
-export interface AgentCache {
-    [key: string]: CacheItem<any>;
-}
-
-export default function addAgent({ name, basePath, headers, query, runner }: AgentOptions) {
+export default function addAgent({ name, basePath, headers, query, runner, cache }: AgentOptions) {
     if(agents[name]) {
         throw new Error(`Agent '${name}' already exists`);
     }
 
     agents[name] = {
         runner,
-        cache: {},
+        cache: cache || new InMemoryCache(),
         basePath,
         headers,
         query,

--- a/src/js/agent/agents.ts
+++ b/src/js/agent/agents.ts
@@ -1,10 +1,10 @@
 import { AbortCall, FetchOptions, Header, QueryParam, RunnerResponse } from '../index';
-import { AgentCache } from './add-agent';
+import { AgentCache } from '../cache-provider';
 
 export interface AgentFetchParams<T> {
     url: string;
     options: FetchOptions;
-    callback: (error: Error, response: RunnerResponse<T>) => void;
+    callback: (error: Error, response: RunnerResponse<T>) => Promise<void>;
 }
 
 export interface Agent {
@@ -16,4 +16,4 @@ export interface Agent {
     runner<T>(options: AgentFetchParams<T>): AbortCall;
 }
 
-export const agents: {[key: string]: Agent} = {};
+export const agents: Record<string, Agent> = {};

--- a/src/js/cache-item/is-garbage/index.spec.ts
+++ b/src/js/cache-item/is-garbage/index.spec.ts
@@ -1,39 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import isGarbage from '.';
+import { AgentCache, InMemoryCache } from '../../cache-provider';
 
 describe('isGarbage',  () => {
+    let cache: AgentCache;
+
     beforeEach(() =>  {
         jest.useFakeTimers();
+        cache = new InMemoryCache();
     });
 
     afterEach(() => {
         jest.useRealTimers();
+        cache = null;
     });
 
-    it('should return false is the cache is not expired', () => {
-        expect(isGarbage({ lastUpdate: Date.now(), cacheTtlMs: 3000, isFetching: false, callbacks: [] })).toBeFalsy();
+    it('should return false is the cache is not expired', async () => {
+        const cacheItem: any = { key: 'test1', lastUpdate: Date.now(), cacheTtlMs: 3000, isFetching: false, callbacks: [] };
+        await cache.setItem(cacheItem.key, cacheItem);
+        await expect(isGarbage({ key: cacheItem.key, cache })).resolves.toBeFalsy();
     });
-
-    it('should return false when the request is still fetching', () => {
-        expect(isGarbage({ lastUpdate: Date.now() - 4000, cacheTtlMs: 3000, isFetching: true, callbacks: [] })).toBeFalsy();
+    
+    it('should return false when the request is still fetching', async () => {
+        const cacheItem: any = { key: 'test1', lastUpdate: Date.now() - 4000, cacheTtlMs: 3000, isFetching: true, callbacks: [] };
+        await cache.setItem(cacheItem.key, cacheItem);
+        await expect(isGarbage({ key: cacheItem.key, cache })).resolves.toBeFalsy();
     });
-
-    it('should return false when there are still callbacks left in queue', () => {
-        expect(isGarbage({
+    
+    it('should return false when there are still callbacks left in queue', async () => {
+        const cacheItem: any = {
+            key: 'test1',
             lastUpdate: Date.now() - 4000,
             cacheTtlMs: 3000,
             isFetching: false,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            callbacks: [ { callback: () => {}, frequencyMs: 0 } ] })
-        ).toBeFalsy();
+            callbacks: [ { callback: () => {}, frequencyMs: 0 } ]
+        };
+        await cache.setItem(cacheItem.key, cacheItem);
+        await expect(isGarbage({ key: cacheItem.key, cache })).resolves.toBeFalsy();
     });
 
-    it('should return true only when cache is expired and request is not fetching and there are no callbacks left in queue', () => {
-        expect(isGarbage({
+    it('should return true only when cache is expired and request is not fetching and there are no callbacks left in queue', async () => {
+        const cacheItem: any = {
+            key: 'test1',
             lastUpdate: Date.now() - 4000,
             cacheTtlMs: 3000,
             isFetching: true,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            callbacks: [ { callback: () => {}, frequencyMs: 0 } ] })
-        ).toBeFalsy();
+            callbacks: [ { callback: () => {}, frequencyMs: 0 } ],
+        };
+        await cache.setItem(cacheItem.key, cacheItem);
+        await expect(isGarbage({ key: cacheItem.key, cache })).resolves.toBeFalsy();
     });
 });

--- a/src/js/cache-item/is-garbage/index.ts
+++ b/src/js/cache-item/is-garbage/index.ts
@@ -1,6 +1,13 @@
-import { CacheItem } from '../..';
-import isExpired from '../is-expired';
+import { AgentCache } from '../../cache-provider';
 
-export default function isGarbage<T>(cacheItem: Pick<CacheItem<T>, 'callbacks' | 'isFetching' | 'cacheTtlMs' | 'lastUpdate'>): boolean {
-    return isExpired(cacheItem) && !cacheItem.isFetching && !cacheItem.callbacks.length;
+interface IsGarbageParams {
+    key: string;
+    cache: AgentCache;
+}
+
+export default async function isGarbage({ key, cache }: IsGarbageParams) {
+    const isExpired = await cache.isExpired(key);
+    const { isFetching, callbacks } = await cache.getItem(key);
+
+    return isExpired && !isFetching && !callbacks.length;
 }

--- a/src/js/cache-item/run/index.ts
+++ b/src/js/cache-item/run/index.ts
@@ -23,5 +23,6 @@ export default function run<T>(agent: Pick<Agent, 'runner'>, cacheItem: CacheIte
     if(cacheItem.abort) {
         cacheItem.abort();
     }
+
     cacheItem.abort = agent.runner<T>({ url: cacheItem.url, options: cacheItem.options, callback: cacheItem.callback });
 }

--- a/src/js/cache-provider/index.ts
+++ b/src/js/cache-provider/index.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CacheItem } from '../';
+import { expiresIn, isExpired } from '../cache-item';
+
+export interface AgentCache {
+  getItem<T = any>(key: string): Promise<CacheItem<T>>;
+  setItem<T = any>(key: string, value: CacheItem<T>): Promise<void>;
+  deleteItem(key: string): Promise<void>;
+  getAllKeys(): Promise<string[]>;
+  getAllValues(): Promise<CacheItem<any>[]>;
+  clearCache(): Promise<void>;
+  expiresIn(key: string): Promise<number>;
+  isExpired(key: string): Promise<boolean>;
+}
+
+export class InMemoryCache implements AgentCache {
+  cache: Record<string, CacheItem<any>>;
+
+  constructor() {
+    this.cache = Object.create(null);
+  }
+
+  async getItem<T>(key: string): Promise<CacheItem<T>> {
+    return this.cache[key];
+  }
+
+  async setItem<T>(key: string, value: CacheItem<T>) {
+    this.cache[key] = value;
+  }
+
+  async deleteItem(key: string) {
+    delete this.cache[key];
+  }
+
+  async getAllKeys() {
+    return Object.keys(this.cache);
+  }
+
+  async getAllValues() {
+    return Object.values(this.cache);
+  }
+
+  async clearCache(): Promise<void> {
+    this.cache = Object.create(null);
+  }
+
+  async expiresIn(key: string) {
+    return expiresIn(this.cache[key]);
+  }
+
+  async isExpired(key: string) {
+    return isExpired(this.cache[key]);
+  }
+}

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -5,7 +5,7 @@ import asPromise from './as-promise';
 import removeAllAgents from './agent/remove-all-agents';
 import removeAgent from './agent/remove-agent';
 
-export type CallbackHandler<T> = (err: Error, res?: CallbackResponse<T>) => void;
+export type CallbackHandler<T> = (err: Error, res?: CallbackResponse<T>) => Promise<void>;
 export type AbortCall = () => void;
 
 export interface RunnerResponse<T> {
@@ -56,7 +56,7 @@ export interface CacheItem<T> {
     nextRefresh: ReturnType<typeof setTimeout>;
     options: FetchOptions;
     abort: AbortCall;
-    callback: (error: Error, response: RunnerResponse<T>) => void;
+    callback: (error: Error, response: RunnerResponse<T>) => Promise<void>;
 }
 
 export interface CallbackRecord<T> {


### PR DESCRIPTION
The idea is to update `cache[key]` get/set to have a dedicated function for each like `getItem`, `setItem`, `deleteItem`, and `clearCache` but this results in a major refactor because the setter that is happening now might no longer work because the cache must be serialized/deserialized each time we want to access/update a value from a cache provider.

Also, this will result in a lot of async behavior and causes some pain in tests.