### PR TITLE
feat: add cache storage

### DIFF
--- a/src/js/agent/add-agent/index.ts
+++ b/src/js/agent/add-agent/index.ts
@@ -7,6 +7,7 @@ export interface AgentOptions {
     basePath: string;
     headers?: Header[];
     query?: QueryParam[];
+    storage?: AgentCacheStorage;
     runner<T>(options: AgentFetchParams<T>): AbortCall;
 }
 
@@ -14,7 +15,14 @@ export interface AgentCache {
     [key: string]: CacheItem<any>;
 }
 
-export default function addAgent({ name, basePath, headers, query, runner }: AgentOptions) {
+export interface AgentCacheStorage {
+    getItem: <T>(key: string) => Promise<T>;
+    setItem: (key: string, value: any) => Promise<void>;
+    removeItem: (key: string) => Promise<void>;
+    clear: () => Promise<void>;
+}
+
+export default function addAgent({ name, basePath, headers, query, storage, runner }: AgentOptions) {
     if(agents[name]) {
         throw new Error(`Agent '${name}' already exists`);
     }
@@ -22,6 +30,7 @@ export default function addAgent({ name, basePath, headers, query, runner }: Age
     agents[name] = {
         runner,
         cache: {},
+        storage,
         basePath,
         headers,
         query,

--- a/src/js/agent/agents.ts
+++ b/src/js/agent/agents.ts
@@ -1,8 +1,11 @@
 import { AbortCall, FetchOptions, Header, QueryParam, RunnerResponse } from '../index';
-import { AgentCache } from './add-agent';
+import { AgentCache, AgentCacheStorage } from './add-agent';
+import { CacheResult } from '../cache-item/run';
 
 export interface AgentFetchParams<T> {
+    key?: string;
     url: string;
+    getCache?: () => Promise<CacheResult<T>>;
     options: FetchOptions;
     callback: (error: Error, response: RunnerResponse<T>) => void;
 }
@@ -13,7 +16,8 @@ export interface Agent {
     headers?: Header[];
     query?: QueryParam[];
     garbageCollectorTimeout: ReturnType<typeof setTimeout>;
+    storage?: AgentCacheStorage;
     runner<T>(options: AgentFetchParams<T>): AbortCall;
 }
 
-export const agents: {[key: string]: Agent} = {};
+export const agents: Record<string, Agent> = {};

--- a/src/js/agent/remove-agent/index.ts
+++ b/src/js/agent/remove-agent/index.ts
@@ -1,10 +1,12 @@
 import { agents } from '../agents';
 
 export default function removeAgent(name: string) {
-    if(!agents[name]) {
+    if (!agents[name]) {
         return;
     }
+
     clearTimeout(agents[name].garbageCollectorTimeout);
 
     delete agents[name];
+    agents[name].storage?.clear();
 }

--- a/src/js/as-callback/index.ts
+++ b/src/js/as-callback/index.ts
@@ -85,9 +85,9 @@ export default function asCallback<T>({ agentName, path, options = {}, frequency
     manageGarbage(agent);
 
     const { cacheTtlMs = 0, force = false } = options.cacheOptions ?? {};
-    const cacheItem = getItem<T>({ cache: agent.cache, key, cacheTtlMs, options: runnerOptions, url });
+    const cacheItem = getItem<T>({ cache: agent.cache, storage: agent.storage, key, cacheTtlMs, options: runnerOptions, url });
     cacheItem.callbacks.push({ callback, frequencyMs });
     processState({ agent, cacheItem, frequencyMs, force });
-    
+
     return (): void => stopFeed(cacheItem, callback);
 }

--- a/src/js/cache-item/get-item/index.ts
+++ b/src/js/cache-item/get-item/index.ts
@@ -1,9 +1,10 @@
 import { CacheItem, RunnerResponse, FetchOptions } from '../..';
-import { AgentCache } from '../../agent/add-agent';
+import { AgentCache, AgentCacheStorage } from '../../agent/add-agent';
 import { resolveCallbacks } from '..';
 
 interface CacheItemProps {
     cache: AgentCache;
+    storage?: AgentCacheStorage;
     key: string;
     url: string;
     cacheTtlMs: number;
@@ -19,12 +20,12 @@ function saveResult<T>(cacheItem: CacheItem<T>, error: Error, response: RunnerRe
     cacheItem.lastUpdate = Date.now();
 }
 
-export default function getItem<T>({ cache, key, cacheTtlMs, options, url }: CacheItemProps): CacheItem<T> {
+export default function getItem<T>({ cache, storage, key, cacheTtlMs, options, url }: CacheItemProps): CacheItem<T> {
     if(!cache[key]) {
         const cacheItem: CacheItem<T> = {
             key,
             url,
-            cacheTtlMs: cacheTtlMs,
+            cacheTtlMs,
             callbacks: [],
             lastUpdate: null,
             value: null,
@@ -40,6 +41,7 @@ export default function getItem<T>({ cache, key, cacheTtlMs, options, url }: Cac
                 }
 
                 saveResult(cacheItem, error, response);
+                storage?.setItem(key, cacheItem);
                 resolveCallbacks(cacheItem);
             }
         };

--- a/src/js/cache-item/run/index.ts
+++ b/src/js/cache-item/run/index.ts
@@ -2,6 +2,11 @@ import { Agent } from '../../agent/agents';
 import { CacheItem } from '../..';
 import getLowestFrequency from '../get-lowest-frequency';
 
+export type CacheResult<T> = {
+    status: 'missing' | 'success' | 'failed';
+    result: T | undefined;
+};
+
 export function reRun<T>(agent: Pick<Agent, 'runner'>, cacheItem: CacheItem<T>):void {
     // When there are multiple callbacks with different frequencies the polling system will pick the lowest frequency to run at
     // and bypass cache ttl in order to avoid more complex logic that would be required to manage multiple frequencies.
@@ -13,15 +18,41 @@ export function reRun<T>(agent: Pick<Agent, 'runner'>, cacheItem: CacheItem<T>):
     }
 }
 
-export default function run<T>(agent: Pick<Agent, 'runner'>, cacheItem: CacheItem<T>): void {
+export async function getCache<T>(key: string, storage?: Agent['storage']): Promise<CacheResult<T>> {
+    if (!storage?.getItem) {
+        return { status: 'missing', result: undefined };
+    }
+
+    try {
+        const result = await storage.getItem<T>(key);
+
+        if (result === undefined) {
+            return { status: 'missing', result };
+        }
+
+        return { status: 'success', result };
+    } catch (error) {
+        return { status: 'failed', result: error };
+    }
+}
+
+export default function run<T>(agent: Pick<Agent, 'runner' | 'storage'>, cacheItem: CacheItem<T>): void {
     reRun(agent, cacheItem);
+
     if(cacheItem.isFetching || !cacheItem.callbacks.length) {
         return;
     }
 
     cacheItem.isFetching = true;
+
     if(cacheItem.abort) {
         cacheItem.abort();
     }
-    cacheItem.abort = agent.runner<T>({ url: cacheItem.url, options: cacheItem.options, callback: cacheItem.callback });
+
+    cacheItem.abort = agent.runner<T>({
+        url: cacheItem.url,
+        options: cacheItem.options,
+        callback: cacheItem.callback,
+        getCache: () => getCache<T>(cacheItem.key, agent.storage),
+    });
 }

--- a/src/js/manage-garbage/index.ts
+++ b/src/js/manage-garbage/index.ts
@@ -2,13 +2,17 @@ import { Agent } from '../agent/agents';
 import { isGarbage } from '../cache-item';
 
 export const garbageCollectorFrequency = 9000;
-export type GarbageAgent = Pick<Agent, 'cache' | 'garbageCollectorTimeout'>;
+export type GarbageAgent = Pick<Agent, 'cache' | 'garbageCollectorTimeout' | 'storage'>;
 
 function runGarbageCollector(agent: GarbageAgent): void {
-    const { cache } = agent;
+    const { cache, storage } = agent;
+
     Object.values(cache)
         .filter(isGarbage)
-        .forEach((cacheItem) => delete cache[cacheItem.key]);
+        .forEach(({ key }) => {
+            delete cache[key];
+            storage?.removeItem(key);
+        });
 
     agent.garbageCollectorTimeout = Object.keys(cache).length
         ? setTimeout(() => runGarbageCollector(agent), garbageCollectorFrequency)


### PR DESCRIPTION
This is my 2nd approach where less change but the getter side should be done on the userland in the `runner` declaration.

```js
addAgent({
  runner: ({ url, storage, key, callback }) => {
    storage.getItem(key)
      .then((result) => {
        if (!result) {
          return true;
        }

        const { error, response, status } = result;

        if (error) {
          callback(error);
        } else {
          callback(null, { data, status }); 
        }

        return false;
      })
      .then((canFetch) => canFetch && fetch())
      .then(async (response) => response && callback(null, { data: await response.json(), status: response.status }))
      .catch((error) => callback(error)});
  },
});
```

I'll add tests only after this has been finalized 😉 